### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
-
+  
 RUN apt-get -qq update && \
-    apt-get -qq -y install ffmpeg && \
+    apt-get -qq -y install ffmpeg gcc && \
     apt-get autoclean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -9,4 +9,4 @@ COPY ./ /app/
 WORKDIR /app
 RUN pip3 install -r requirements.txt
 
-ENTRYPOINT ["python3", "/app/main.py", "--config_file", "/app/config/config.ini"]
+ENTRYPOINT ["python3", "/app/main.py", "--config", "/app/config/config.ini"]


### PR DESCRIPTION
addition of pycrypto as a requirement needs gcc in order for the container to install it